### PR TITLE
update strava embeds due to their deprecation of the old style embed

### DIFF
--- a/src/bayway.html
+++ b/src/bayway.html
@@ -7,7 +7,9 @@
 <!--
 <div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="8065040803"></div><script src="https://strava-embeds.com/embed.js"></script>-->
           <div class="strava_container">
-<iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/542889/embed/1f12d3778dccb63f800580cbee4206ffbd263f9e'></iframe>
+<div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="542889" data-style="standard"
+          data-from-embed="false" data-token="RKk8dh-jUC4XPtUhQVrCcfO9C4G9bietTc54VC-TWPI"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
 <div class="route_help">
             <p><b>Bayway</b> is the "standard" commute for most rides, most of the time. 

--- a/src/colmaway.html
+++ b/src/colmaway.html
@@ -5,7 +5,9 @@
       <div class="two_col">
         <div class="left">
           <div class="strava_container">
-            <iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='http://app.strava.com/rides/517016/embed/b94d754c1ce4ae0857be7ab23e89dd0191887fd8'></iframe>
+            <div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="13724128514"
+          data-style="standard" data-from-embed="false" data-token="rhLSrKvcUPG65--6YIa328YKriI7fAtDgOeNjoOL_N0"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
           </div>
           <div class="route_help">
             <p>A variant of <a href="bayway.html">bayway</a> that involves

--- a/src/febw.html
+++ b/src/febw.html
@@ -5,7 +5,9 @@
       <div class="two_col">
         <div class="left">
           <div class="strava_container">
-<iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/222746/embed/39b14945d136445c5b0ccf2853538754df28072f'></iframe>
+<div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="222746" data-style="standard"
+          data-from-embed="false" data-token="KMnZVzjr0M8SmCKuTgi0qXV9iH8Z6rsMgGl8p186KnA"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
 <div class="route_help">
             <p><b>East Bay Skyline, aka Far East Bay Way (FEBW)</b> is a truly epic "commute" along the lines of Half Moon Bay Way. It's long, hilly, challenging, and beautiful, with stunning views and ideal cycling roads. It does require a BART ride and a very early wakeup, so it's not really an everyday thing, but you should try it at least once. A sunny fall or spring day is ideal, as it does get pretty hot out there.

--- a/src/fleaway.html
+++ b/src/fleaway.html
@@ -5,7 +5,9 @@
       <div class="two_col">
         <div class="left">
           <div class="strava_container">
-<iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/8127111/embed/0c6ca235308cefebea04697d3accf7aa78a883ee'></iframe>
+<div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="8127111" data-style="standard"
+          data-from-embed="false" data-token="MdqhN-oRQq3fgUJXN_R2QCnZNuKrKsh4MrIlLpk25hM"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
 <div class="route_help">
             <p><b>Fleaway</b>, so-named because much of the route uses Avenida de las Pulgas (fleas),  is not often ridden but is worth a try. It pretty neatly splits the habitable peninsula and includes some legit hills if that's your bag. It also "features" some narrow roads with surly morning car traffic, so be careful of that.

--- a/src/hmbw.html
+++ b/src/hmbw.html
@@ -6,7 +6,9 @@
         <div class="left">
           <div class="strava_container">
 
-          <iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/614286/embed/7387d5f5fe491139ec323499a65c36987e7c411e'></iframe>
+          <div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="614286" data-style="standard"
+          data-from-embed="false" data-token="ooWlxRD1Bon7r5BonySKpIK7q3y57jA6yqIVLh9tPa4"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
 <div class="route_help">
             <p><b>Half Moon Bay Way</b>, while somewhat impractical for commuting, is one of the more awesome ways to get to work in the bay area, if not the world. Cruise down highway 1, go up the spectacular and legburning Tunitas Creek Road, and back down Kings Mountain Road's tight switchbacks. A gorgeous ride, highly recommended if you have time.</p>

--- a/src/mebw.html
+++ b/src/mebw.html
@@ -4,7 +4,9 @@
       <h1><a href="routes.html">&laquo;</a> Middle East Bay Way</h1>
       <div class="two_col">
         <div class="left">
-          <div class="strava_container"><iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/143176030/embed/662cf6877378cbe303044d50c26c2a01d2539f77'></iframe>
+          <div class="strava_container"><div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="143176030" data-style="standard"
+          data-from-embed="false" data-token="YWeVMnX7cPw0K9n2CIjRoYnc_OItyr_qa6KDRPe4x2g"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
 <div class="route_help">
             <p><b>Middle East Bay Way (MEBW)</b> is one of the more unusual "commutes" you're likely to encounter, and is admittedly not super practical. But it is amazing. It starts with a BART ride to the east bay, followed by some worming through some rough industrial areas. Then suddenly you find a nice tranquil bike path heading straight out into the bay, and then you're IN THE BAY, with water on both sides, for miles and miles. This ride is largely on dirt, and the route is replete with turns that may not be very obvious. It is advisable to try this ride with an experienced guide the first time, especially if you actually need to be at work that day! EQUIPMENT NOTE: This ride can be done on a road bike with slicks, but there are loose dirt sections, so you may consider your cyclocross bike or even a rigid mountain bike. But a road bike will be fastest. Definitely bring at least 2 extra tubes and perhaps an extra tire. It's pretty rough in parts.

--- a/src/royale.html
+++ b/src/royale.html
@@ -5,7 +5,9 @@
       <div class="two_col">
         <div class="left">
           <div class="strava_container">
-<iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/11292454/embed/0c9816e9c41325b451dfc017bbc54ce86bba9f50'></iframe>
+<div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="11292454" data-style="standard"
+          data-from-embed="false" data-token="mSOAuHdfxl7LWbxqjFgs1vuzn6NEdqpXBsEWNdN5QWA"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
 <div class="route_help">
             <p><b>Royale</b> is the fastest way down the peninsula short of riding on 101 itself (on a day without cars). It's also the simplest possible route: just head south on Mission St. and keep going. This is the original 101, before it was moved to the Bayshore Highway and expanded. CA-82, as it's now known, was also the original Mission Trail and has long been called El Camino Real, The Royal Road.  It gets "with cheese" because of all the wacky, weird, oddball businesses you see along its length. This is the Peninsula's original Main Street, and it's like a time capsule.

--- a/src/skyline.html
+++ b/src/skyline.html
@@ -6,7 +6,9 @@
         <div class="left">
           <div class="strava_container">
 
-          <iframe height='405' width='590' frameborder='0' allowtransparency='true' scrolling='no' src='https://www.strava.com/activities/58557/embed/fecdce0ead95af2f8ceffa3ba392c305b60cc3b8'></iframe>
+          <div class="strava-embed-placeholder" data-embed-type="activity" data-embed-id="58557" data-style="standard"
+          data-from-embed="false" data-token="5OywuV0dIn8XcBYXmBQ5dhOG1KvYOc4BTfZQ3KljG5I"></div>
+        <script src="https://strava-embeds.com/embed.js"></script>
 </div>
           <div class="route_help">
             <p><b>Skyline</b> is the benchmark awesome commute in the bay area, with knockout scenery, scenic bike paths, tough climbs, and fast flats. 


### PR DESCRIPTION
see: bottom of https://support.strava.com/hc/en-us/articles/216918527-Sharing-Your-Activities-and-Routes-With-a-Strava-Embed
embeds broke, this updates to strava's new tag.