### PR TITLE
update gtag property code away from non-functional UA (GA3) code

### DIFF
--- a/src/sf2gheader.html
+++ b/src/sf2gheader.html
@@ -4,14 +4,14 @@
   <title>SF2G: commute by bike from san francisco to the south bay!</title>
   <link rel="stylesheet" type="text/css" href="css/sf2g.css">
 
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-86288-9"></script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=AW-957290940"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-86288-9');
+  gtag('config', 'AW-957290940');
 </script>
 
 


### PR DESCRIPTION
pointing this temporarily to my internal dollar-a-day adwords account for conversion tracking, we can switch it to GA4 if whoever owns the GA instance wants to upgrade it.